### PR TITLE
Updating the layout for day events to not overlap each other

### DIFF
--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -108,7 +108,7 @@ function sortByRender(events) {
 }
 
 function findContainers(eventToFind, events, minimumStartDifference) {
-  const resultContiners = []
+  const resultContainers = []
   let q = []
   let vertices = new Map()
 
@@ -122,7 +122,7 @@ function findContainers(eventToFind, events, minimumStartDifference) {
   while (q.length > 0) {
     let container = q.shift()
     if (containsEvent(eventToFind, container, minimumStartDifference)) {
-      resultContiners.push(container)
+      resultContainers.push(container)
     }
     if (container.rows) {
       container.rows.forEach(r => {
@@ -134,7 +134,7 @@ function findContainers(eventToFind, events, minimumStartDifference) {
     }
   }
 
-  return resultContiners
+  return resultContainers
 }
 
 function containsEvent(event, container, minimumStartDifference) {

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -85,15 +85,10 @@ function sortByRender(events) {
     const event = sortedByTime.shift()
     sorted.push(event)
 
-    // let lastEndms = event.endMs;
     for (let i = 0; i < sortedByTime.length; i++) {
       const test = sortedByTime[i]
 
       // Still inside this event, look for next.
-      // if (lastEndms > test.startMs) {
-      //   lastEndms = Math.max(lastEndms, test.endMs);
-      //   continue;
-      // }
       if (event.endMs > test.startMs) continue
 
       // We've found the first event of the next event group.

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -21,6 +21,7 @@ describe('getStyledEvents', () => {
         const results = styledEvents.map(result => ({
           width: Math.floor(result.style.width),
           xOffset: Math.floor(result.style.xOffset),
+          id: result.event.id,
         }))
         expect(results).toEqual(expectedResults)
       })
@@ -87,6 +88,40 @@ describe('getStyledEvents', () => {
           { width: 33, xOffset: 0 },
           { width: 33, xOffset: 33 },
           { width: 33, xOffset: 66 },
+        ],
+      ],
+      [
+        'cascade of overlapping events',
+        [
+          { start: d(11), end: d(12), id: 'test1' },
+          { start: d(11, 30), end: d(15, 30), id: 'test2' },
+          { start: d(13), end: d(13, 30), id: 'test3' },
+          { start: d(14), end: d(14, 30), id: 'test4' },
+          { start: d(12), end: d(13, 0), id: 'test5' },
+        ],
+        [
+          { width: 33, xOffset: 0, id: 'test1' },
+          { width: 33, xOffset: 0, id: 'test5' },
+          { width: 33, xOffset: 33, id: 'test2' },
+          { width: 33, xOffset: 66, id: 'test3' },
+          { width: 33, xOffset: 66, id: 'test4' },
+        ],
+      ],
+      [
+        'cascade of overlapping events with stair stepping overlap',
+        [
+          { start: d(11), end: d(12, 30), id: 'test1' },
+          { start: d(11, 30), end: d(15, 30), id: 'test2' },
+          { start: d(11, 30), end: d(12, 30), id: 'test3' },
+          { start: d(12, 30), end: d(13, 0), id: 'test4' },
+          { start: d(14), end: d(15, 30), id: 'test5' },
+        ],
+        [
+          { width: 33, xOffset: 0, id: 'test1' },
+          { width: 33, xOffset: 0, id: 'test4' },
+          { width: 33, xOffset: 33, id: 'test2' },
+          { width: 33, xOffset: 66, id: 'test3' },
+          { width: 33, xOffset: 66, id: 'test5' },
         ],
       ],
     ]


### PR DESCRIPTION
Creating a solution so events to not overlap each other.  This requires a change to how it calculates event width and xOffset.  Instead of tracking with child rows and leaves it tracks with a column count and does tree lookup for intersecting events as well as updating column counts in the tree.